### PR TITLE
hinawa-rs: snd_unit: generate open method for derived objects

### DIFF
--- a/conf/gir-hinawa.toml
+++ b/conf/gir-hinawa.toml
@@ -9,7 +9,6 @@ generate = [
     "Hinawa.FwRcode",
     "Hinawa.FwTcode",
     "Hinawa.SndUnitType",
-    "Hinawa.SndUnit",
     "Hinawa.SndDice",
     "Hinawa.SndMotu",
     "Hinawa.SndDg00x",
@@ -55,6 +54,15 @@ manual_traits = ["FwFcpExtManual"]
     pattern = "transaction"
     ignore = true
     doc_trait_name = "FwFcpExtManual"
+
+[[object]]
+name = "Hinawa.SndUnit"
+status = "generate"
+manual_traits = ["SndUnitExtManual"]
+    [[object.function]]
+    pattern = "open"
+    ignore = true
+    doc_trait_name = "SndUnitExtManual"
 
 [[object]]
 name = "Hinawa.SndEfw"

--- a/hinawa/src/auto/mod.rs
+++ b/hinawa/src/auto/mod.rs
@@ -28,6 +28,7 @@ pub use self::snd_dice::SndDiceExt;
 
 mod snd_efw;
 pub use self::snd_efw::{SndEfw, SndEfwClass, NONE_SND_EFW};
+pub use self::snd_efw::SndEfwExt;
 
 mod snd_motu;
 pub use self::snd_motu::{SndMotu, SndMotuClass, NONE_SND_MOTU};
@@ -54,6 +55,7 @@ pub mod traits {
     pub use super::FwRespExt;
     pub use super::SndDg00xExt;
     pub use super::SndDiceExt;
+    pub use super::SndEfwExt;
     pub use super::SndMotuExt;
     pub use super::SndTscmExt;
     pub use super::SndUnitExt;

--- a/hinawa/src/auto/snd_dg00x.rs
+++ b/hinawa/src/auto/snd_dg00x.rs
@@ -2,6 +2,7 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
+use glib;
 use glib::object::Cast;
 use glib::object::IsA;
 use glib::signal::connect_raw;
@@ -13,6 +14,7 @@ use libc;
 use std::boxed::Box as Box_;
 use std::fmt;
 use std::mem::transmute;
+use std::ptr;
 use SndUnit;
 
 glib_wrapper! {
@@ -40,10 +42,20 @@ impl Default for SndDg00x {
 pub const NONE_SND_DG00X: Option<&SndDg00x> = None;
 
 pub trait SndDg00xExt: 'static {
+    fn open(&self, path: &str) -> Result<(), glib::Error>;
+
     fn connect_message<F: Fn(&Self, u32) + 'static>(&self, f: F) -> SignalHandlerId;
 }
 
 impl<O: IsA<SndDg00x>> SndDg00xExt for O {
+    fn open(&self, path: &str) -> Result<(), glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let _ = hinawa_sys::hinawa_snd_dg00x_open(self.as_ref().to_glib_none().0, path.to_glib_none().0, &mut error);
+            if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
+        }
+    }
+
     fn connect_message<F: Fn(&Self, u32) + 'static>(&self, f: F) -> SignalHandlerId {
         unsafe extern "C" fn message_trampoline<P, F: Fn(&P, u32) + 'static>(this: *mut hinawa_sys::HinawaSndDg00x, message: libc::c_uint, f: glib_sys::gpointer)
             where P: IsA<SndDg00x>

--- a/hinawa/src/auto/snd_dice.rs
+++ b/hinawa/src/auto/snd_dice.rs
@@ -42,12 +42,22 @@ impl Default for SndDice {
 pub const NONE_SND_DICE: Option<&SndDice> = None;
 
 pub trait SndDiceExt: 'static {
+    fn open(&self, path: &str) -> Result<(), glib::Error>;
+
     fn transaction(&self, addr: u64, frame: &[u32], bit_flag: u32) -> Result<(), glib::Error>;
 
     fn connect_notified<F: Fn(&Self, u32) + 'static>(&self, f: F) -> SignalHandlerId;
 }
 
 impl<O: IsA<SndDice>> SndDiceExt for O {
+    fn open(&self, path: &str) -> Result<(), glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let _ = hinawa_sys::hinawa_snd_dice_open(self.as_ref().to_glib_none().0, path.to_glib_none().0, &mut error);
+            if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
+        }
+    }
+
     fn transaction(&self, addr: u64, frame: &[u32], bit_flag: u32) -> Result<(), glib::Error> {
         let frame_count = frame.len() as usize;
         unsafe {

--- a/hinawa/src/auto/snd_efw.rs
+++ b/hinawa/src/auto/snd_efw.rs
@@ -2,9 +2,12 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
+use glib;
+use glib::object::IsA;
 use glib::translate::*;
 use hinawa_sys;
 use std::fmt;
+use std::ptr;
 use SndUnit;
 
 glib_wrapper! {
@@ -30,6 +33,20 @@ impl Default for SndEfw {
 }
 
 pub const NONE_SND_EFW: Option<&SndEfw> = None;
+
+pub trait SndEfwExt: 'static {
+    fn open(&self, path: &str) -> Result<(), glib::Error>;
+}
+
+impl<O: IsA<SndEfw>> SndEfwExt for O {
+    fn open(&self, path: &str) -> Result<(), glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let _ = hinawa_sys::hinawa_snd_efw_open(self.as_ref().to_glib_none().0, path.to_glib_none().0, &mut error);
+            if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
+        }
+    }
+}
 
 impl fmt::Display for SndEfw {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/hinawa/src/auto/snd_motu.rs
+++ b/hinawa/src/auto/snd_motu.rs
@@ -2,6 +2,7 @@
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // DO NOT EDIT
 
+use glib;
 use glib::object::Cast;
 use glib::object::IsA;
 use glib::signal::connect_raw;
@@ -13,6 +14,7 @@ use libc;
 use std::boxed::Box as Box_;
 use std::fmt;
 use std::mem::transmute;
+use std::ptr;
 use SndUnit;
 
 glib_wrapper! {
@@ -40,10 +42,20 @@ impl Default for SndMotu {
 pub const NONE_SND_MOTU: Option<&SndMotu> = None;
 
 pub trait SndMotuExt: 'static {
+    fn open(&self, path: &str) -> Result<(), glib::Error>;
+
     fn connect_notified<F: Fn(&Self, u32) + 'static>(&self, f: F) -> SignalHandlerId;
 }
 
 impl<O: IsA<SndMotu>> SndMotuExt for O {
+    fn open(&self, path: &str) -> Result<(), glib::Error> {
+        unsafe {
+            let mut error = ptr::null_mut();
+            let _ = hinawa_sys::hinawa_snd_motu_open(self.as_ref().to_glib_none().0, path.to_glib_none().0, &mut error);
+            if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
+        }
+    }
+
     fn connect_notified<F: Fn(&Self, u32) + 'static>(&self, f: F) -> SignalHandlerId {
         unsafe extern "C" fn notified_trampoline<P, F: Fn(&P, u32) + 'static>(this: *mut hinawa_sys::HinawaSndMotu, message: libc::c_uint, f: glib_sys::gpointer)
             where P: IsA<SndMotu>

--- a/hinawa/src/auto/snd_unit.rs
+++ b/hinawa/src/auto/snd_unit.rs
@@ -52,8 +52,6 @@ pub trait SndUnitExt: 'static {
 
     fn lock(&self) -> Result<(), glib::Error>;
 
-    fn open(&self, path: &str) -> Result<(), glib::Error>;
-
     fn unlock(&self) -> Result<(), glib::Error>;
 
     fn get_property_card(&self) -> u32;
@@ -103,14 +101,6 @@ impl<O: IsA<SndUnit>> SndUnitExt for O {
         unsafe {
             let mut error = ptr::null_mut();
             let _ = hinawa_sys::hinawa_snd_unit_lock(self.as_ref().to_glib_none().0, &mut error);
-            if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
-        }
-    }
-
-    fn open(&self, path: &str) -> Result<(), glib::Error> {
-        unsafe {
-            let mut error = ptr::null_mut();
-            let _ = hinawa_sys::hinawa_snd_unit_open(self.as_ref().to_glib_none().0, path.to_glib_none().0, &mut error);
             if error.is_null() { Ok(()) } else { Err(from_glib_full(error)) }
         }
     }

--- a/hinawa/src/lib.rs
+++ b/hinawa/src/lib.rs
@@ -22,6 +22,9 @@ pub use fw_resp::*;
 mod fw_fcp;
 pub use fw_fcp::*;
 
+mod snd_unit;
+pub use snd_unit::*;
+
 mod snd_efw;
 pub use snd_efw::*;
 

--- a/hinawa/src/snd_unit.rs
+++ b/hinawa/src/snd_unit.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+use glib::object::IsA;
+use glib::translate::*;
+
+use SndUnit;
+
+pub trait SndUnitExtManual {
+    fn open(&self, path: &str) -> Result<(), glib::Error>;
+}
+
+impl<O: IsA<SndUnit>> SndUnitExtManual for O {
+    fn open(&self, path: &str) -> Result<(), glib::Error> {
+        unsafe {
+            let mut error = std::ptr::null_mut();
+
+            let _ = hinawa_sys::hinawa_snd_unit_open(
+                self.as_ref().to_glib_none().0,
+                path.to_glib_none().0,
+                &mut error,
+            );
+
+            if error.is_null() {
+                Ok(())
+            } else {
+                Err(from_glib_full(error))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch fixes issue #1.

In libhinawa, HinawaSndUnit has open method (=hinawa_snd_unit_open()) and
derived objects override it by own method. However the overridden methods
are missing from API crate as of hinawa-rs v0.1.0.

Affected objects and methods are:

    HinawaSndDg00x (hinawa_snd_dg00x_open)
    HinawaSndDice (hinawa_snd_dice_open)
    HinawaSndEfw (hinawa_snd_efw_open)
    HinawaSndMotu (hinawa_snd_motu_open)
    HinawaSndTscm (hinawa_snd_tscm_open)

This is due to the design of gtk-rs/gir. According to issue #139, when
derived objects override parent method, binding is not generated for the
methods to generate binding for the parent method. Therefore it's expected
not to generate bindings for the above methods.

This commit fixes the bug. A configuration is added to suppress binding
generation for the parent method. Then the overridden methods are
generated for derived object automatically in each trait. A manual binding
for the parent method is added by hand in manual trait. Users can decide
which open method is used by selecting the traits.

Reference: https://github.com/gtk-rs/gtk/pull/425
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>