### PR TITLE
Download glib related crates from crates.io and use workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[workspace]
+members = [
+    "hinawa-sys",
+    "hinawa",
+]
+
+default-members = [
+    "hinawa",
+]

--- a/hinawa-sys/Cargo.toml
+++ b/hinawa-sys/Cargo.toml
@@ -14,11 +14,8 @@ name = "hinawa_sys"
 [dependencies]
 libc = "0.2"
 
-[dependencies.glib-sys]
-git = "https://github.com/gtk-rs/sys"
-
-[dependencies.gobject-sys]
-git = "https://github.com/gtk-rs/sys"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/hinawa/Cargo.toml
+++ b/hinawa/Cargo.toml
@@ -9,9 +9,10 @@ name = "hinawa"
 
 [dependencies]
 libc = "0.2"
-glib = { git = "https://github.com/gtk-rs/glib" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
+
+glib = "0.10"
+glib-sys = "0.10"
+gobject-sys = "0.10"
 hinawa-sys = { path = "../hinawa-sys" }
 
 [dev-dependencies]

--- a/hinawa/Cargo.toml
+++ b/hinawa/Cargo.toml
@@ -13,7 +13,8 @@ libc = "0.2"
 glib = "0.10"
 glib-sys = "0.10"
 gobject-sys = "0.10"
-hinawa-sys = { path = "../hinawa-sys" }
+
+hinawa-sys = { path = "../hinawa-sys", version = "0.1" }
 
 [dev-dependencies]
 gir-format-check = "^0.1"


### PR DESCRIPTION
All of included crates have dependencies to glib related crates. in v0.1.0 release, they are downloaded from repository github.com. Althouth this is preferable for development, downloading from crates.io is preferable for published crates.

Additionally, Cargo has a feature called as 'Workspace'. This is usefull in the case that several crates are under controlled.

This patchset changes download sources of depending glib related crates and workspace.